### PR TITLE
Improved identification of tracklets

### DIFF
--- a/notebooks/Demonstrate_Sifter_PreCalc_and_SQLStorage_Functionality.ipynb
+++ b/notebooks/Demonstrate_Sifter_PreCalc_and_SQLStorage_Functionality.ipynb
@@ -105,8 +105,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.28 s, sys: 5 ms, total: 1.29 s\n",
-      "Wall time: 1.31 s\n"
+      "CPU times: user 1.32 s, sys: 4 ms, total: 1.33 s\n",
+      "Wall time: 1.35 s\n"
      ]
     }
    ],
@@ -126,11 +126,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data uploaded as required\n"
+      "Data uploaded as required\n",
+      "CPU times: user 17 ms, sys: 2 ms, total: 19 ms\n",
+      "Wall time: 24.1 ms\n"
      ]
     }
    ],
    "source": [
+    "%%time\n",
     "# test that the above caused the tracklet to be uploaded to db\n",
     "cur = T.conn.cursor()\n",
     "cur.execute('SELECT * from tracklets')\n",
@@ -163,8 +166,18 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 46 ms, sys: 0 ns, total: 46 ms\n",
+      "Wall time: 47.6 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time \n",
     "# Where do we want the db to live\n",
     "assert 'sifter' in sql.fetch_db_filepath()\n",
     "\n",
@@ -180,7 +193,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### precalc.parse_all_observations\n",
+    "##### precalc.Tracklets.parse_all_observations\n",
     " - parse a single long list of all observations, splits them into tracklets, performs calculations of (e.g.) HP, RoM, etc, and then creates an summary dictionary for each, and sticking all the dictionaries in a list."
    ]
   },
@@ -188,8 +201,18 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 757 ms, sys: 8 ms, total: 765 ms\n",
+      "Wall time: 754 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time \n",
     "# define observations\n",
     "# Read in ITF (or some small part of it)\n",
     "ITF_file = '../dev_data/test.itf'\n",
@@ -212,7 +235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### precalc.parse_tracklet_observations\n",
+    "##### precalc.Tracklets.parse_tracklet_observations\n",
     " - parse the list of observations for a single tracklet, perform calculations of (e.g.) HP, RoM, etc, and then creates an summary dictionary "
    ]
   },
@@ -220,10 +243,19 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 13 ms, sys: 0 ns, total: 13 ms\n",
+      "Wall time: 13.9 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time \n",
     "# define observations\n",
-    "# *** AT PRESENT THESE ARE JUST DUMMY/BLANK OBS ***\n",
     "tracklet_observations= [ '     K11Q88F*~C2011 08 29.52378 01 57 34.729+14 35 44.64         22.8 rc~0qBd568',\n",
     "                         '     K11Q88F ~C2011 08 29.55470 01 57 34.343+14 35 42.61         22.9 rc~0qBd568',\n",
     "                         '     K11Q88F ~C2011 08 29.61470 01 57 34.343+14 35 42.59         22.9 rc~0qBd568']\n",
@@ -245,16 +277,72 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### precalc.save_tracklets & sql.upsert_tracklets\n",
-    " - Saves a dictionary into a SQLITE db, using JD & HP as important columns for selection/query later-on"
+    "##### precalc.identify_tracklets\n",
+    " - This function takes a long list of observations and identifies tracklets, sticking them together into a list containing a list of observation for each tracklet."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 0 ns, sys: 1 ms, total: 1 ms\n",
+      "Wall time: 245 µs\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time \n",
+    "# Define some observations\n",
+    "# Here we have three dummy triplets, with the last two intentionally using the same trksub\n",
+    "# in order to test that identify_tracklets correctly identifies them as separate tracklets. \n",
+    "observation_list= ['     K11Q88F*~C2011 08 29.52378 01 57 34.729+14 35 44.64         22.8 rc~0qBd568',\n",
+    "                   '     K11Q88F ~C2011 08 29.55470 01 57 34.343+14 35 42.61         22.9 rc~0qBd568',\n",
+    "                   '     K11Q88F ~C2011 08 29.61470 01 57 34.343+14 35 42.59         22.9 rc~0qBd568',\n",
+    "                   '     K11Q99F*~C2012 08 29.52378 01 57 34.729+14 35 44.64         22.8 rc~0qBd568',\n",
+    "                   '     K11Q99F ~C2012 08 29.58470 01 57 34.343+14 35 42.61         22.9 rc~0qBd568',\n",
+    "                   '     K11Q99F ~C2012 08 29.61470 01 57 34.343+14 35 42.59         22.9 rc~0qBd568',\n",
+    "                   '     K11Q99F ~C2018 09 28.52378 01 57 34.729+14 35 44.64         22.8 rc~0qBd568',\n",
+    "                   '     K11Q99F ~C2018 09 28.58470 01 57 34.343+14 35 42.61         22.9 rc~0qBd568',\n",
+    "                   '     K11Q99F ~C2018 09 28.61470 01 57 34.343+14 35 42.59         22.9 rc~0qBd568',\n",
+    "                   ]\n",
+    "# Split into tracklet lists using identify_tracklets:\n",
+    "list_of_lists = precalc.identify_tracklets(observation_list)\n",
+    "# Check that there are three tracklets as expected:\n",
+    "assert len(list_of_lists) == 3\n",
+    "assert len(list_of_lists[0]) == 3\n",
+    "assert len(list_of_lists[1]) == 3\n",
+    "assert len(list_of_lists[2]) == 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### precalc.save_tracklets & sql.upsert_tracklets\n",
+    " - Saves a dictionary into a SQLITE db, using JD & HP as important columns for selection/query later-on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 91 ms, sys: 4 ms, total: 95 ms\n",
+      "Wall time: 135 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time \n",
     "# Create db from scratch\n",
     "test_tracklets.convenience_func_create_db_and_tables()\n",
     "\n",

--- a/sifter/precalc.py
+++ b/sifter/precalc.py
@@ -303,12 +303,31 @@ def identify_tracklets(list_of_observations):
         list of list
         - each containing obs80 lines for obs of a single tracklet.
     '''
+    # Initiate a list with just the first obs of first tracklet to start with.
     list_of_lists = [[list_of_observations[0]]]
+    # Parse all the obs80 lines into a generator
+    parsed_all = parse80(list_of_observations)
+    # Parse 1st line to check whether following lines belong to same tracklet.
+    parsed0 = parsed_all.send(None)
+    JD0 = parsed0.jdutc
+    namestr0 = parsed0.num if parsed0.num != '' else parsed0.desig
+    # Now loop over the rest of the lines, checking whether they belong to
+    # the same tracklet as the previous one.
     for obs in list_of_observations[1:]:
-        if obs[:12] == list_of_lists[-1][-1][:12]:
+        parsed1 = parsed_all.send(None)
+        JD1 = parsed1.jdutc
+        namestr1 = parsed1.num if parsed1.num != '' else parsed1.desig
+        # If next line has same trksub and is within 24 hours, add to tracklet
+        if namestr1 == namestr0 and np.abs(JD1 - JD0 <= 1.0):
             list_of_lists[-1].append(obs)
         else:
             list_of_lists.append([obs])
+            # Update namestr0 so that next loop checks against current line
+            namestr0 = namestr1
+        # Update JD0 so that next loop checks against current line
+        # Updated outside if, so that tracklet can grow infinitely large,
+        # There just has to be no gaps larger than 24 hours.
+        JD0 = JD1
     return list_of_lists
 
 

--- a/sifter/precalc.py
+++ b/sifter/precalc.py
@@ -211,10 +211,10 @@ class Tracklets(Base):
         tracklet_dictionary['AoM'] = Coord.position_angle(Coord2)
 
         # Find the healpix that the coordinates are in.
-        tracklet_dictionary['HP'] = self.HPix.lonlat_to_healpix(Coord.ra,
-                                                                Coord.dec)
-        tracklet_dictionary['HP2'] = self.HPix.lonlat_to_healpix(Coord2.ra,
-                                                                 Coord2.dec)
+        tracklet_dictionary['HP'] = int(self.HPix.lonlat_to_healpix(
+                                        Coord.ra, Coord.dec))
+        tracklet_dictionary['HP2'] = int(self.HPix.lonlat_to_healpix(
+                                         Coord2.ra, Coord2.dec))
 
         # Create a unique ID for the tracklet. This is done by combining
         # the 5 digit number or 6-7 character temporary designation,

--- a/sifter/sql.py
+++ b/sifter/sql.py
@@ -198,7 +198,7 @@ def upsert_tracklets(conn, jd_list, hp_list, tracklet_name_list, tracklet_dict_l
 
     # construct "records" variable which is apparently ammenable to single insert statement ...
     # https://pythonexamples.org/python-sqlite3-insert-multiple-records-into-table/
-    records = [ (jd, hp, tracklet_name, sqlite3.Binary(pickle.dumps(tracklet_dict, pickle.HIGHEST_PROTOCOL))) \
+    records = [ (int(jd), int(hp), tracklet_name, sqlite3.Binary(pickle.dumps(tracklet_dict, pickle.HIGHEST_PROTOCOL))) \
                for jd, hp, tracklet_name, tracklet_dict \
                in zip(jd_list, hp_list, tracklet_name_list, tracklet_dict_list) ]
 


### PR DESCRIPTION
A conversation with Dave revealed that I wasn't identifying tracklets correctly; he said that tot.itf is usually sorted by trksub, which means that naughty tracklets with repeat trksubs will be immediately after each other; the prior implementation of identify_tracklets would not have noticed that these were different tracklets, as it was only looking at the trksub of a line compared to the previous line. Now it also uses the time, for now imposing a limit of 24 hours between sequential observations of a tracklet.
I also demonstrate identify_tracklets in the Demonstrate_Sifter_PreCalc_and_SQLStorage_Functionality.ipynb notebook